### PR TITLE
Throw on invalid glob, clean up, 100% coverage, closes #34

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,12 +61,16 @@ var gs = {
     if (opt.cwdbase) opt.base = opt.cwd;
 
     // only one glob no need to aggregate
-    if (!Array.isArray(globs)) return gs.createStream(globs, [], opt);
+    if (!Array.isArray(globs)) globs = [globs];
 
     var positives = [];
     var negatives = [];
 
     globs.forEach(function(glob, index) {
+      if (typeof glob !== 'string' && !(glob instanceof RegExp)) {
+        throw new Error('Invalid glob at index ' + index);
+      }
+
       var globArray = isNegative(glob) ? negatives : positives;
 
       // create Minimatch instances for negative glob patterns
@@ -104,13 +108,11 @@ var gs = {
 function isMatch(file, matcher) {
   if (matcher instanceof Minimatch) return matcher.match(file.path);
   if (matcher instanceof RegExp) return matcher.test(file.path);
-  return true; // unknown glob type?
 }
 
 function isNegative(pattern) {
-  if (typeof pattern !== 'string') return true;
-  if (pattern[0] === '!') return true;
-  return false;
+  if (typeof pattern === 'string') return pattern[0] === '!';
+  if (pattern instanceof RegExp) return true;
 }
 
 function unrelative(cwd, glob) {

--- a/test/main.js
+++ b/test/main.js
@@ -474,5 +474,15 @@ describe('glob-stream', function() {
       });
     });
 
+    it('should throw on invalid glob argument', function() {
+      gs.create.bind(gs, 42, {cwd: __dirname}).should.throw(/Invalid glob .* 0/);
+      gs.create.bind(gs, ['.', 42], {cwd: __dirname}).should.throw(/Invalid glob .* 1/);
+    });
+
+    it('should throw on missing positive glob', function() {
+      gs.create.bind(gs, '!c', {cwd: __dirname}).should.throw(/Missing positive glob/);
+      gs.create.bind(gs, ['!a', '!b'], {cwd: __dirname}).should.throw(/Missing positive glob/);
+    });
+
   });
 });


### PR DESCRIPTION
- Better naming for negative matchers ( https://github.com/wearefractal/glob-stream/pull/33#issuecomment-68514070 )
- Throw on invalid glob argument ( https://github.com/wearefractal/glob-stream/issues/34#issuecomment-68513629 )
- Removed the `if (!Array.isArray(globs)) return gs.createStream(globs, [], opt);` because this optimization is already covered a couple lines below at `if (positives.length === 1) return streamFromPositive(positives[0]);`, and to not duplicate the validation code. Previously, passing a string with a negative glob did not throw a "Missing positive glob" error, now it does.
